### PR TITLE
Check if socket is ipv4 before setting ttl.

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -41,7 +41,11 @@ pub fn ping(addr: IpAddr, timeout: Option<Duration>, ttl: Option<u32>, ident: Op
         Socket::new(Domain::IPV6, Type::RAW, Some(Protocol::ICMPV6))?
     };
 
-    socket.set_ttl(ttl.unwrap_or(64))?;
+    if dest.is_ipv4() {
+        socket.set_ttl(ttl.unwrap_or(64))?;
+    } else {
+        socket.set_unicast_hops_v6(ttl.unwrap_or(64));
+    }
 
     socket.set_write_timeout(timeout)?;
 


### PR DESCRIPTION
If socket is using ipv6 use set_unicast_hops_v6 instead. Trying to ping an ipv6 address before didn't work.