### PR TITLE
Check whether or not the type or code is wrong.

### DIFF
--- a/src/packet/icmp.rs
+++ b/src/packet/icmp.rs
@@ -74,7 +74,7 @@ impl<'a> EchoReply<'a> {
 
         let type_ = buffer[0];
         let code = buffer[1];
-        if type_ != P::ECHO_REPLY_TYPE && code != P::ECHO_REPLY_CODE {
+        if type_ != P::ECHO_REPLY_TYPE || code != P::ECHO_REPLY_CODE {
             return Err(Error::InvalidPacket)
         }
 


### PR DESCRIPTION
Check whether or not the ICMP packet's type and reply code match. Before, both the reply type and reply code had to be wrong for the packet to be invalidated. With this change, even if the packet has only a wrong reply type or reply code, the packet will be invalidated.