### PR TITLE
✨ Derive Debug and Clone for Ping

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -217,6 +217,7 @@ pub fn ping(
     Ok(())
 }
 
+#[derive(Debug, Clone)]
 pub struct Ping<'a> {
     socket_type: SocketType,
     addr: IpAddr,


### PR DESCRIPTION
Add `#[derive(Debug, Clone)]` to the `Ping` builder so callers can debug-print and clone a configured pinger.