### PR TITLE
Fix ICMP reply decoding robustness

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,8 +6,6 @@ pub enum Error {
     InvalidProtocol,
     #[error("internal error")]
     InternalError,
-    #[error("Decode V4 error occurred while processing the IPv4 packet.")]
-    DecodeV4Error,
     #[error("Decode echo reply error occurred while processing the ICMP echo reply.")]
     DecodeEchoReplyError,
     #[error("io error: {error}")]

--- a/src/packet/icmp.rs
+++ b/src/packet/icmp.rs
@@ -2,6 +2,8 @@ use std::io::Write;
 use thiserror::Error;
 
 pub const HEADER_SIZE: usize = 8;
+/// Size of the correlation token carried as the echo payload.
+pub const PAYLOAD_SIZE: usize = 24;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -68,7 +70,7 @@ pub struct EchoReply<'a> {
 
 impl<'a> EchoReply<'a> {
     pub fn decode<P: Proto>(buffer: &'a [u8]) -> Result<Self, Error> {
-        if buffer.as_ref().len() < HEADER_SIZE {
+        if buffer.as_ref().len() < HEADER_SIZE + PAYLOAD_SIZE {
             return Err(Error::InvalidSize);
         }
 
@@ -80,7 +82,7 @@ impl<'a> EchoReply<'a> {
 
         let ident = (u16::from(buffer[4]) << 8) + u16::from(buffer[5]);
         let seq_cnt = (u16::from(buffer[6]) << 8) + u16::from(buffer[7]);
-        let payload = &buffer[HEADER_SIZE..(HEADER_SIZE + 24)];
+        let payload = &buffer[HEADER_SIZE..(HEADER_SIZE + PAYLOAD_SIZE)];
 
         Ok(EchoReply {
             ident,

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -137,9 +137,12 @@ fn ping_with_socktype(
                     Err(_) => continue,
                 }
             } else {
+                // Skip undecodable IP packets (malformed, truncated, or
+                // unrelated ICMP traffic from other hosts on a RAW socket)
+                // instead of failing the whole ping; keep waiting for our reply.
                 let ipv4_packet = match IpV4Packet::decode(&buffer) {
                     Ok(packet) => packet,
-                    Err(_) => return Err(Error::DecodeV4Error.into()),
+                    Err(_) => continue,
                 };
                 recv_ttl = Some(ipv4_packet.ttl);
                 match EchoReply::decode::<IcmpV4>(ipv4_packet.data) {


### PR DESCRIPTION
This fixes two robustness issues in the reply-receiving loop. First, when an incoming IPv4 packet fails to decode (malformed, truncated, or unrelated ICMP traffic delivered on a RAW socket), the loop now skips it and keeps waiting for our own reply instead of aborting the entire ping with an error. This previously caused spurious failures, particularly on Windows where RAW sockets are the default and receive all ICMP traffic on the host.

Second, `EchoReply::decode` only checked that the buffer was at least `HEADER_SIZE` (8) bytes before slicing out the 24-byte payload at `[8..32]`, so any buffer between 8 and 31 bytes would panic on an out-of-bounds index. The length check now requires the full header plus payload, and the magic number is replaced with a new `PAYLOAD_SIZE` constant. The now-unused `Error::DecodeV4Error` variant is removed as well; note this is a breaking change to the public `Error` enum.