### PR TITLE
Decode replies using actual received length

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -132,7 +132,7 @@ fn ping_with_socktype(
         let reply = if dest.is_ipv4() {
             // DGRAM socket on Linux may return pure ICMP packet without IP header.
             if n == ECHO_REQUEST_BUFFER_SIZE {
-                match EchoReply::decode::<IcmpV4>(&buffer) {
+                match EchoReply::decode::<IcmpV4>(&buffer[..n]) {
                     Ok(reply) => reply,
                     Err(_) => continue,
                 }
@@ -140,7 +140,7 @@ fn ping_with_socktype(
                 // Skip undecodable IP packets (malformed, truncated, or
                 // unrelated ICMP traffic from other hosts on a RAW socket)
                 // instead of failing the whole ping; keep waiting for our reply.
-                let ipv4_packet = match IpV4Packet::decode(&buffer) {
+                let ipv4_packet = match IpV4Packet::decode(&buffer[..n]) {
                     Ok(packet) => packet,
                     Err(_) => continue,
                 };
@@ -151,7 +151,7 @@ fn ping_with_socktype(
                 }
             }
         } else {
-            match EchoReply::decode::<IcmpV6>(&buffer) {
+            match EchoReply::decode::<IcmpV6>(&buffer[..n]) {
                 Ok(reply) => reply,
                 Err(_) => continue,
             }


### PR DESCRIPTION
When decoding replies, the code previously passed the whole 2048-byte zero-filled buffer instead of slicing it to `n`, the number of bytes actually returned by `recv_from`. This changes all three decode paths to use `&buffer[..n]`: bare IPv4 ICMP, IPv4 with IP-header stripping, and IPv6.

As a result, the inner ICMP length extracted by `IpV4Packet::decode` reflects the real packet length rather than including trailing zero padding. Combined with the previously tightened length check in `EchoReply::decode`, short or malformed replies now return `InvalidSize` and get skipped by the loop, instead of having a bogus payload read out of the zero padding. The `n == 32` branch still holds, since a RAW reply always carries an IP header and is therefore at least 52 bytes, so it can never be mistaken for the bare-ICMP branch.